### PR TITLE
Add host user wrapper for Docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Containers for scientific computing
 
-This repository is a work-in-progress collection of tools, recipes, and workflows for container-based scientific computing. It might serve as a basis for "best practice" developments, especially when it comes to the actual portability of scientific computing container images.
+This repository is a work-in-progress collection of tools, recipes, and workflows for container-based scientific computing. It might serve as a basis for "best practice" developments, especially when it comes to the actual portability of containers for scientific computing applications.
 
 ## Docker
 
@@ -9,13 +9,20 @@ This repository is a work-in-progress collection of tools, recipes, and workflow
 Files created inside a Docker container, especially those that are (in good practice!) created by non-root container user accounts, will have unpredictable ownerships when inspected from the host system.
 Furthermore, files created with the host system user account will likely be inaccessible from inside a container environment.
 
+#### Docker flags: Build-in approach
+
+You might simply use `docker run --user $(id -u):$(id -g) --group-add <put-container-group-here>`.
+This explicitely runs the container process as host system user, and therefore prevents the file permission problem.
+The `--group-add` flag assigns the host system user to a group inside the container environment, which might preserve the rights of the default container user for the host user, and with that to e.g. interactively adapt the container environment.
+For this approach, no `Dockerfile` adaptions are necessary.
+Since the host system user might not exist inside the container environment (i.e. listed in the `/etc/passwd` and `/etc/groups`) some applications might refuse to work.
+In that case, the wrapper script approach below can be used.
+It can also be used to prevent the shell sessions warnings about non-existing users and/or group entries.
+
 #### Wrapper script: Merging user account information
 
-The wrapper script [as-host-user.sh](as-host-user.sh) is a hacky solution, but provides a very quick and user-friendly way of solving the Docker volume file permission problem when it comes to simply executing a container application.
-It does not require any `Dockerfile` adaptions (that might impede container portability across several host systems, such as e.g. with specifying the target system host user during a Docker image build) and/or changing any Docker daemon / host system defaults (that could have unconsidered side effects, especially if set up by unexperienced container application users).
+The wrapper script [as-host-user.sh](as-host-user.sh) automates the above solution, and provides a hacky, but clean and quick way of solving the Docker volume file permission problem described above.
+It does not require any `Dockerfile` adaptions (that might impede container portability across several host systems, such as e.g. with specifying the target system host user during a Docker image build) and/or changing any Docker daemon / host system defaults (that could have unconsidered side effects, especially if set up by unexperienced users).
 
-The drawback of wrapping a `docker run` is that the possibility of interactively adapting the container environment is lost, as the default Linux file system permissions are designed to act preventive.
-Selectively adjusting file permissions with a `chmod a=u <application-folder>` in the `Dockerfile`, such as e.g. for a conda environment and/or an already specified non-root user directory, could then be a workaround.
-However, for such use cases better see the `setuidgid` approach below.
-
-#### GOSU, setuidgid, ...
+The drawback of wrapping a `docker run` is that, depending on the file ownership settings in the container, that the possibility of interactively adapting the container environment is lost.
+You might be able to use `--group-add <put-container-group-here>` (see above!) to circumvent this, though.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,16 @@ This repository is a work-in-progress collection of tools, recipes, and workflow
 
 ### Host user mapping
 
-Files created inside a Docker container, especially those that are (in good practice) created by non-root container user accounts, will have unpredictable ownerships when inspected from the host system.
+Files created inside a Docker container, especially those that are (in good practice!) created by non-root container user accounts, will have unpredictable ownerships when inspected from the host system.
 Furthermore, files created with the host system user account will likely be inaccessible from inside a container environment.
 
-The wrapper script [as-host-user.sh](as-host-user.sh) provides a very quick, user-friendly and portable solution to the Docker volume file permission problem and does not require any Dockerfile adaptions (that might impede container portability across several host systems) and/or changing any Docker daemon or host system defaults (that could have unconsidered side effects, especially for unexperienced users).
-A stumbling block is that you might loose the ability to interactively adapt a container's system environment.
+#### Wrapper script: Merging user account information
+
+The wrapper script [as-host-user.sh](as-host-user.sh) is a hacky solution, but provides a very quick and user-friendly way of solving the Docker volume file permission problem when it comes to simply executing a container application.
+It does not require any `Dockerfile` adaptions (that might impede container portability across several host systems, such as e.g. with specifying the target system host user during a Docker image build) and/or changing any Docker daemon / host system defaults (that could have unconsidered side effects, especially if set up by unexperienced container application users).
+
+The drawback of wrapping a `docker run` is that the possibility of interactively adapting the container environment is lost, as the default Linux file system permissions are designed to act preventive.
+Selectively adjusting file permissions with a `chmod a=u <application-folder>` in the `Dockerfile`, such as e.g. for a conda environment and/or an already specified non-root user directory, could then be a workaround.
+However, for such use cases better see the `setuidgid` approach below.
+
+#### GOSU, setuidgid, ...

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# containers-for-scientific-computing
+# Containers for scientific computing
+
+This repository is a work-in-progress collection of tools, recipes, and workflows for container-based scientific computing. It might serve as a basis for "best practice" developments, especially when it comes to the actual portability of scientific computing container images.
+
+## Docker
+
+### Host user mapping
+
+Files created inside a Docker container, especially those that are (in good practice) created by non-root container user accounts, will have unpredictable ownerships when inspected from the host system.
+Furthermore, files created with the host system user account will likely be inaccessible from inside a container environment.
+
+The wrapper script [as-host-user.sh](as-host-user.sh) provides a very quick, user-friendly and portable solution to the Docker volume file permission problem and does not require any Dockerfile adaptions (that might impede container portability across several host systems) and/or changing any Docker daemon or host system defaults (that could have unconsidered side effects, especially for unexperienced users).
+A stumbling block is that you might loose the ability to interactively adapt a container's system environment.

--- a/as-host-user.sh
+++ b/as-host-user.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Very simple usage instructions.
+
+echo "$@" | grep -e '--help' --quiet && \
+echo "./as-host-user.sh --image [image] --command [docker run ...]" && exit
+
+# Verify that we are on a Linux machine.
+# This wrapper is not necessary on MacOS systems, as Docker volumes are mounted via NFS.
+# Not sure about Windows, but execution is prevented as well.
+
+echo $(uname -s) | grep -e "Linux" --quiet || { echo Not a Linux host machine... exiting.; exit; }
+
+# Check if Docker is available.
+
+docker --version || { echo Docker not found... exiting.; exit; }
+
+# Check if Docker image and Docker command are specified.
+
+echo "$@" | grep -e '--image' --quiet || { echo --image not specified... exiting.; exit; }
+echo "$@" | grep -e '--command' --quiet || { echo --command not specified... exiting.; exit; }
+
+# Check if a `docker run` command is specified.
+
+echo "$@" | grep -e 'docker run' --quiet || { echo No docker run command found... exiting.; exit; }
+
+# Parse the inputs.
+
+for ARG in "$@"; do
+ case $ARG in
+   --image) shift; DOCKER_IMAGE=$1; shift ;;
+   --command) shift; ORIGINAL_DOCKER_COMMAND="$@" ;;
+ esac
+done
+
+ORIGINAL_DOCKER_COMMAND="$@"
+echo Original command: ${ORIGINAL_DOCKER_COMMAND}
+echo Enable host user for: ${DOCKER_IMAGE}
+
+# Prepare temporary directory for merging the Linux system account information.
+
+TEMPDIR=$(mktemp -d $(pwd)/tmp.XXXXXXXX)
+echo Temporary directory: ${TEMPDIR}
+trap "echo Deleting: ${TEMPDIR}; rm -rf ${TEMPDIR}" 0
+
+# Extract existing Docker image account information and append (replace with) the user account information of the host system.
+
+id=$(docker create jupyter)
+# https://stackoverflow.com/questions/25292198/docker-how-can-i-copy-a-file-from-an-image-to-a-host
+docker cp $id:/etc/passwd ${TEMPDIR}/etc_passwd
+docker cp $id:/etc/group ${TEMPDIR}/etc_group
+docker rm $id
+
+# If UID is already existing, remove the container's user...
+sed "/$(id -u ${USER})/d" $TEMPDIR/etc_passwd > $TEMPDIR/etc_passwd
+sed "/$(id -g ${USER})/d" $TEMPDIR/etc_group > $TEMPDIR/etc_group
+
+# Append host system user information.
+grep $(id -u ${USER}) /etc/passwd >> ${TEMPDIR}/etc_passwd
+grep $(id -g ${USER}) /etc/group >> ${TEMPDIR}/etc_group
+
+# Setup necessary Docker options.
+
+USER_FLAGS="-u $(id -u ${USER}):$(id -g ${USER})"
+MOUNT_FLAGS="-v ${TEMPDIR}/etc_passwd:/etc/passwd -v ${TEMPDIR}/etc_group:/etc/group"
+
+FINAL_DOCKER_COMMAND=${ORIGINAL_DOCKER_COMMAND//docker run/docker run ${USER_FLAGS} ${MOUNT_FLAGS}}
+echo Will execute: ${FINAL_DOCKER_COMMAND}
+
+# Execute final Docker command.
+
+${FINAL_DOCKER_COMMAND}


### PR DESCRIPTION
Hacky, but portable and especially ready-to-use solutions to circumvent the Linux file permission problems that appear during the work on files created inside and outside of container environments.